### PR TITLE
Fix for double-evaluating quoted args

### DIFF
--- a/Bakefile
+++ b/Bakefile
@@ -27,6 +27,12 @@ function coffee {
     bake_ok "coffe" "compiled"
 }
 
+#. Repeats the input. params: text
+function repeat {
+    bake_params text
+
+    printf "text was: '%s'\n" "$text"
+}
 
 function on_task_not_found {
     echo "Task not found $1"

--- a/bake
+++ b/bake
@@ -268,7 +268,7 @@ main() {
           echo $arg | grep -Eq "\w+=(\w+)?"
           if [ "$?" == "0" ]; then
             # preserve quoted args by re-quoting before passing to eval
-            eval "$(echo $arg | cut -d'=' -f1)=\"$(echo $arg | cut -d'=' -f2)\""
+            eval "$(echo $arg | cut -d'=' -f1)='$(echo $arg | cut -d= -f2)'"
           fi
         done
 


### PR DESCRIPTION
This fix prevents bake from re-evaluating args that were single quoted on the command line.

To confirm, note the difference when the following is invoked on the included Bakefile: 
```
export some_var=empty
bake repeat text="${some_variable}"
bake repeat text='${some_variable}'
```
The expected output is:
```
text was: 'empty'
text was: '${some_var}'
```
While before this fix, the output was:
```
text was: 'empty'
text was: 'empty'
```