### PR TITLE
handle nested includes properly

### DIFF
--- a/Bakefile
+++ b/Bakefile
@@ -1,4 +1,4 @@
-include "./includes/*"
+include "includes/*"
 
 function private {
     echo in private

--- a/bake
+++ b/bake
@@ -131,20 +131,44 @@ print_task_list () {
     ((max_width+=2))
 
     while read -r name desc; do
-      desc=$(echo ${desc} | sed 's/params:/\'${C_IGREEN}'params:\'${C_CYAN}'/')
-      printf "${C_GREEN}%-${max_width}s${C_OFF} ${desc}${C_OFF}\n" $name
+      if [[ -n "${name}" ]]; then
+        desc=$(echo ${desc} | sed 's/params:/\'${C_IGREEN}'params:\'${C_CYAN}'/')
+        printf "${C_GREEN}%-${max_width}s${C_OFF} ${desc}${C_OFF}\n" $name
+      fi
     done < <(echo "${list}")
+
+    # submodules
+    if [[ -n "$(find ${bakefile_dir} -d 2 -name Bakefile -type f)" ]]; then
+        printf "\n${C_IGREEN}submodules:${C_OFF}\n"
+        for submodule in $(find . -d 2 -name Bakefile -type f); do
+            echo "$(basename $(dirname $submodule))"
+        done
+    fi
+
 }
 
 # Includes an external script.
 #
 # @param $1 File pattern to include
 include () {
+
+    local abs_bakefile_dir=$(cd $bakefile_dir 2>/dev/null && pwd || true)
+    local incoming_directory=$(pwd)
+    if [[ $abs_bakefile_dir == $incoming_directory* ]] && [[ $abs_bakefile_dir != $incoming_directory ]]; then
+        # if bakefile_dir is a subdirectory of PWD, jump to bakefile_dir
+        pushd $abs_bakefile_dir  > /dev/null
+    fi
+
     local files=$1
-    for file in $(ls -d -1 $files); do
+    for file in $(find $files -d 0 -type f); do
         task_list $file
-        source $file
+        pushd $(dirname $file) > /dev/null
+        source $(basename $file)
+        popd > /dev/null
     done
+    if [[ $abs_bakefile_dir == $incoming_directory* ]] && [[ $abs_bakefile_dir != $incoming_directory ]]; then
+        popd  > /dev/null
+    fi
 }
 
 # Invokes function once.

--- a/includes/inc2
+++ b/includes/inc2
@@ -4,3 +4,12 @@ function boop {
 
     $bake beep
 }
+
+include "nested/*"
+
+#. Herp derp
+function herp {
+    bake_ok "herp..."
+
+    $bake derp
+}

--- a/includes/nested/inc3
+++ b/includes/nested/inc3
@@ -1,0 +1,10 @@
+#. Derps the project
+function derp {
+  bake_ok derp!
+  invoke yet_another_private_function
+  bake_ok "pwd: $(pwd)"
+}
+
+yet_another_private_function() {
+  bake_ok "called another private derp function..."
+}

--- a/mymodule/Bakefile
+++ b/mymodule/Bakefile
@@ -1,0 +1,7 @@
+
+#. Builds the project
+function build {
+    # ensures clean is called only once
+    invoke clean
+    bake_ok building ...
+}


### PR DESCRIPTION
This allows for nested includes, and fixes the behavior of includes when bake is called with a directory as it's first argument.

Additionally, a printout of `submodules` is added which lists directories one level deep which also contain Bakefiles.