### PR TITLE
added 'bake_depends'; allows Make-like deps

### DIFF
--- a/Bakefile
+++ b/Bakefile
@@ -34,6 +34,14 @@ function repeat {
     printf "text was: '%s'\n" "$text"
 }
 
+#. A function with dependencies. params: a, b
+function has_depends {
+    bake_params a b
+    bake_depends dep1 dep2
+
+    bake_info "has_depends"
+}
+
 function on_task_not_found {
     echo "Task not found $1"
 }

--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ Includes external script(s).
     example: include "includes/*"
  - _Note: use `$bake` to invoke bake from an included task retaining the original top level directory_
 
+Declare dependendent tasks that are `invoke`'d.
+    bake_depends <task>...
+
+ - _Note: `bake_depends` can be called at any point within a task._
+
 
 Run a dynamic task when task `$1` is not found. For example, to run
 a test as the first argument to `bake`, add this to `Bakefile`

--- a/bake
+++ b/bake
@@ -177,15 +177,15 @@ include () {
 invoke () {
     local invoked
     for f in "$@"; do
+        set +ue
         eval "invoked=\$$1_invoked"
+        set -ue
         if [ ! "$invoked" == "1" ]; then
             eval $1_invoked=1
             "$@"
         fi
     done
 }
-
-
 
 # Converts name=value arguments to vars
 #
@@ -198,10 +198,22 @@ function bake_params {
   for param in "$@"; do
     local val=$(eval echo \${$param:-})
     if [ -z "$val" ]; then
-      bake_error "$param parameter is missing." && exit 1
+      bake_error "'$param' parameter is missing." && exit 1
     fi
   done
   set -ue
+}
+
+# Assures that a set of function
+#
+# @example
+#   bake_depends "build"
+#
+# @param... Names of targets to invoke
+function bake_depends {
+    for target in $@; do
+        invoke $target
+    done
 }
 
 # Prints a log message with no color.
@@ -231,7 +243,8 @@ bake_error () {
 # @param $1 action
 # @param $2 description
 bake_info () {
-    echo -e "${C_CYAN}      $1\t${C_ICYAN}${2}${C_OFF}"
+    local description=${2:-}
+    echo -e "${C_CYAN}      $1\t${C_ICYAN}${description}${C_OFF}"
 }
 
 
@@ -250,7 +263,8 @@ bake_ok () {
 # @param $1 Exit code.
 # @param $2 [optional] Message.
 bake_exit() {
-    [[ -n $2 ]] && echo $2
+    local message=${2:-}
+    [[ -n $message ]] && echo $message
     exit $1
 }
 
@@ -275,6 +289,7 @@ outdated() {
 
     return 1
 }
+
 
 
 # Main entry point into program.
@@ -357,6 +372,7 @@ scriptdir() {
     eval $__resultvar="$(cd `dirname "$1"` && cd -P "$__real" && pwd )"
 }
 
+
 bake_app=`basename $0`
 this_bake="$(cd `dirname $0` && pwd)/${bake_app}"
 case "$1" in
@@ -385,6 +401,7 @@ case "$1" in
             # setting the bake_app displays usage with the script name instead of `bake`
             bake_app=`basename $1`
             bakefile=$1
+            # TODO: attempt to make this local so that globals are not overwritten
             bakefile_dir=$PWD
             shift
             main "$@"
@@ -405,4 +422,3 @@ case "$1" in
         fi
         ;;
 esac
-

--- a/includes/nested/inc3
+++ b/includes/nested/inc3
@@ -8,3 +8,16 @@ function derp {
 yet_another_private_function() {
   bake_ok "called another private derp function..."
 }
+
+#. dep 1. params: a, b
+function dep1 {
+  bake_params a b
+  bake_info "dep1: a=$a b=$b"
+  invoke dep2
+}
+
+#. dep 1. params: a, b
+function dep2 {
+  bake_params a b
+  bake_info "dep2: a=$a b=$b"
+}


### PR DESCRIPTION
This commit adds `bake_depends` which is mostly syntactic sugar to declare Make-like dependencies.

Also includes a fix for 'bake_info' when the optional message is not supplied.
